### PR TITLE
Add TypeScript v2 API client and Next.js route handlers

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 API_BASE_URL=https://api.stakewiz.com/
+STAKEWIZ_API_BASE=https://staging-api.stakewiz.com
+STAKEWIZ_API_TOKEN=stz_1Kd6L3CsnjvkqX-PG370JVOebs2ItN7T
 GA_TRACKING_ID=abc
 RPC_URL=https://thrilling-palpable-shadow.solana-mainnet.quiknode.pro/2d3b9a121eabafdc8d62a8f8ea86934153c88d22/

--- a/components/common.tsx
+++ b/components/common.tsx
@@ -263,14 +263,18 @@ const getAllEpochHistory = async (): Promise<Object> => {
 
 const ValidatorData = async() => {
 
-  return await new Promise((resolve, reject) => {
-    axios('/api/v2/validators/').then(response => {
-      resolve(response.data.data);
-    })
-    .catch(error => {
-      reject(error);
-    });
-  });
+  const all: any[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const url = '/api/v2/validators/?limit=1000' + (cursor ? '&cursor=' + encodeURIComponent(cursor) : '');
+    const response = await axios(url);
+    const { data, next_cursor } = response.data;
+    all.push(...data);
+    cursor = next_cursor;
+  } while (cursor);
+
+  return all;
 
 };
 

--- a/components/common.tsx
+++ b/components/common.tsx
@@ -232,14 +232,10 @@ const checkSolflareEnabled = async (pubkey: string): Promise<boolean> => {
 const getEpochInfo = async (): Promise<Object> => {
 
   
-  let result = await axios(API_URL+config.API_ENDPOINTS.epoch_info, {
-      headers: {'Content-Type':'application/json'}
-  })
+  let result = await axios('/api/v2/epoch/info')
     .then(response => {
       if(response.status==200) return response.data;
       else return false;
-
-      
     })
     .catch(e => {
       console.log(e);
@@ -252,14 +248,10 @@ const getEpochInfo = async (): Promise<Object> => {
 const getAllEpochHistory = async (): Promise<Object> => {
 
   
-  let result = await axios(API_URL+config.API_ENDPOINTS.all_epoch_history, {
-      headers: {'Content-Type':'application/json'}
-  })
+  let result = await axios('/api/v2/epoch/history')
     .then(response => {
       if(response.status==200) return response.data;
       else return false;
-
-      
     })
     .catch(e => {
       console.log(e);
@@ -272,10 +264,8 @@ const getAllEpochHistory = async (): Promise<Object> => {
 const ValidatorData = async() => {
 
   return await new Promise((resolve, reject) => {
-    axios(API_URL+config.API_ENDPOINTS.validators, {
-    headers: {'Content-Type':'application/json'}
-    }).then(response => {
-      resolve(response.data);
+    axios('/api/v2/validators/').then(response => {
+      resolve(response.data.data);
     })
     .catch(error => {
       reject(error);
@@ -287,9 +277,7 @@ const ValidatorData = async() => {
 const WalletValidators = async(pubkey) => {
 
   return await new Promise((resolve, reject) => {
-    axios(API_URL+config.API_ENDPOINTS.wallet_validators+'/'+pubkey, {
-    headers: {'Content-Type':'application/json'}
-    }).then(response => {
+    axios('/api/v2/stake/by_withdraw_authority/'+pubkey).then(response => {
       resolve(response.data);
     })
     .catch(error => {
@@ -301,14 +289,10 @@ const WalletValidators = async(pubkey) => {
 };
 
 export const getClusterStats = async ():Promise<clusterStatsI> => {
-    
-  try {
-    let response = await axios(API_URL+config.API_ENDPOINTS.cluster_stats, {
-      headers: {'Content-Type':'application/json'}
-    })
-    let json = response.data;
 
-    return json
+  try {
+    let response = await axios('/api/v2/cluster_stats')
+    return response.data;
    }
    catch(e) {
       console.log(e);

--- a/components/navbar-search.tsx
+++ b/components/navbar-search.tsx
@@ -5,7 +5,6 @@ import { ValidatorContext } from './validator/validatorhook'
 import { useRouter } from 'next/router'
 const ordinal = require ('ordinal');
 
-const API_URL = process.env.API_BASE_URL;
 
 interface ValidatorData {
   name: string;

--- a/components/stake/common.tsx
+++ b/components/stake/common.tsx
@@ -6,7 +6,6 @@ import config from '../../config.json';
 import axios from 'axios';
 import { CommissionHistoryI, JitoCommissionHistoryI } from './interfaces'
 
-const API_URL = process.env.API_BASE_URL;
 
 export const getStakeAccounts = async (pubkey,connection: Connection) => {
 
@@ -32,9 +31,7 @@ export const getStakeAccounts = async (pubkey,connection: Connection) => {
 export const getCommissionHistory = async (vote_identity):Promise<CommissionHistoryI[]> => {
     
     try {
-      let response = await axios(API_URL+config.API_ENDPOINTS.commission_history+'/'+vote_identity, {
-        headers: {'Content-Type':'application/json'}
-      })
+      let response = await axios('/api/v2/validator/'+vote_identity+'/commission_history')
       let json = response.data;
   
       return json
@@ -48,9 +45,7 @@ export const getCommissionHistory = async (vote_identity):Promise<CommissionHist
 export const getJitoCommissionHistory = async (vote_identity):Promise<JitoCommissionHistoryI[]> => {
 
     try {
-        let response = await axios(API_URL+config.API_ENDPOINTS.jito_commission_history+'/'+vote_identity, {
-        headers: {'Content-Type':'application/json'}
-        })
+        let response = await axios('/api/v2/validator/'+vote_identity+'/jito_commission_history')
         let json = response.data;
 
         return json

--- a/components/stake/interfaces.tsx
+++ b/components/stake/interfaces.tsx
@@ -6,5 +6,5 @@ export interface CommissionHistoryI {
 
 export interface JitoCommissionHistoryI {
     commission_bps: number;
-    created_at: string;
+    observed_at: string;
 }

--- a/components/validator.tsx
+++ b/components/validator.tsx
@@ -307,19 +307,19 @@ const ValidatorBox: FC<ValidatorBoxPropsI> = ({validator,clusterStats,showWizMod
 
         let stakeText, stakeColor, stakeBg, stakeWidth;
         if(validator.stake_ratio > config.STAKE_CATEGORIES.HIGH) {
-            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
+            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake)));
             stakeColor = 'text-danger';
             stakeBg = 'bg-danger';
             stakeWidth = 100;
         }
         else if(validator.stake_ratio > config.STAKE_CATEGORIES.MEDIUM) {
-            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
+            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake)));
             stakeColor = 'text-warning';
             stakeBg = 'bg-warning';
             stakeWidth = validator.stake_ratio*1000;
         }
         else {
-            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9)); 
+            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake))); 
             stakeColor = 'text-success';
             stakeBg = 'bg-success';
             stakeWidth = validator.stake_ratio*1000;

--- a/components/validator.tsx
+++ b/components/validator.tsx
@@ -14,7 +14,6 @@ import { ValidatorContext } from './validator/validatorhook'
 import ordinal from 'ordinal'
 import WizEmblem from '../public/images/emblem.svg'
 
-const API_URL = process.env.API_BASE_URL;
 
 class ValidatorListing extends React.Component<ValidatorListingI, {}> {
     constructor(props, context ) {
@@ -50,9 +49,7 @@ class ValidatorListing extends React.Component<ValidatorListingI, {}> {
     }
 
     getWalletValidators(pubkey) {
-      axios(API_URL+config.API_ENDPOINTS.wallet_validators+'/'+pubkey, {
-          headers: {'Content-Type':'application/json'}
-      })
+      axios('/api/v2/stake/by_withdraw_authority/'+pubkey)
         .then(response => {
           let json = response.data;
           

--- a/components/validator.tsx
+++ b/components/validator.tsx
@@ -307,19 +307,19 @@ const ValidatorBox: FC<ValidatorBoxPropsI> = ({validator,clusterStats,showWizMod
 
         let stakeText, stakeColor, stakeBg, stakeWidth;
         if(validator.stake_ratio > config.STAKE_CATEGORIES.HIGH) {
-            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake)));
+            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
             stakeColor = 'text-danger';
             stakeBg = 'bg-danger';
             stakeWidth = 100;
         }
         else if(validator.stake_ratio > config.STAKE_CATEGORIES.MEDIUM) {
-            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake)));
+            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
             stakeColor = 'text-warning';
             stakeBg = 'bg-warning';
             stakeWidth = validator.stake_ratio*1000;
         }
         else {
-            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake))); 
+            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9)); 
             stakeColor = 'text-success';
             stakeBg = 'bg-success';
             stakeWidth = validator.stake_ratio*1000;

--- a/components/validator.tsx
+++ b/components/validator.tsx
@@ -307,19 +307,19 @@ const ValidatorBox: FC<ValidatorBoxPropsI> = ({validator,clusterStats,showWizMod
 
         let stakeText, stakeColor, stakeBg, stakeWidth;
         if(validator.stake_ratio > config.STAKE_CATEGORIES.HIGH) {
-            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Number(validator.activated_stake.toFixed(0)));
+            stakeText = 'High Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
             stakeColor = 'text-danger';
             stakeBg = 'bg-danger';
             stakeWidth = 100;
         }
         else if(validator.stake_ratio > config.STAKE_CATEGORIES.MEDIUM) {
-            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Number(validator.activated_stake.toFixed(0)));
+            stakeText = 'Medium Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9));
             stakeColor = 'text-warning';
             stakeBg = 'bg-warning';
             stakeWidth = validator.stake_ratio*1000;
         }
         else {
-            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Number(validator.activated_stake.toFixed(0))); 
+            stakeText = 'Low Stake: ◎ '+new Intl.NumberFormat().format(Math.round(Number(validator.activated_stake) / 1e9)); 
             stakeColor = 'text-success';
             stakeBg = 'bg-success';
             stakeWidth = validator.stake_ratio*1000;
@@ -529,7 +529,7 @@ const ValidatorBox: FC<ValidatorBoxPropsI> = ({validator,clusterStats,showWizMod
                 >
                     <div className={'bg-wizlight rounded text-center flex-grow-1 m-1'+(showListView?' w-70':'')}>
                         <div className='p-2'>   
-                            {validator.credit_ratio.toFixed(1)}%
+                            {Number(validator.credit_ratio).toFixed(1)}%
                         </div>
                         <div>
                             

--- a/components/validator/ValidatorList.tsx
+++ b/components/validator/ValidatorList.tsx
@@ -44,8 +44,8 @@ const ValidatorList: React.FC<ValidatorListProps> = ({ validators, onValidatorCl
                 <div className="text-center">
                   <h6 className="mb-1">Stake</h6>
                   <p className="mb-0 text-primary">
-                    {validator.activated_stake ? 
-                      `${(validator.activated_stake / 1e9).toLocaleString()} SOL` : 
+                    {validator.activated_stake ?
+                      `${Number(validator.activated_stake).toLocaleString()} SOL` :
                       'N/A'}
                   </p>
                 </div>

--- a/components/validator/ValidatorList.tsx
+++ b/components/validator/ValidatorList.tsx
@@ -45,7 +45,7 @@ const ValidatorList: React.FC<ValidatorListProps> = ({ validators, onValidatorCl
                   <h6 className="mb-1">Stake</h6>
                   <p className="mb-0 text-primary">
                     {validator.activated_stake ?
-                      `${Number(validator.activated_stake).toLocaleString()} SOL` :
+                      `${Math.round(Number(validator.activated_stake) / 1e9).toLocaleString()} SOL` :
                       'N/A'}
                   </p>
                 </div>

--- a/components/validator/ValidatorList.tsx
+++ b/components/validator/ValidatorList.tsx
@@ -36,7 +36,7 @@ const ValidatorList: React.FC<ValidatorListProps> = ({ validators, onValidatorCl
                 <div className="text-center">
                   <h6 className="mb-1">Score</h6>
                   <Badge bg="primary" className="fs-6">
-                    {validator.wiz_score?.toFixed(2) || 'N/A'}
+                    {validator.wiz_score != null ? Number(validator.wiz_score).toFixed(2) : 'N/A'}
                   </Badge>
                 </div>
               </Col>

--- a/components/validator/ValidatorList.tsx
+++ b/components/validator/ValidatorList.tsx
@@ -45,7 +45,7 @@ const ValidatorList: React.FC<ValidatorListProps> = ({ validators, onValidatorCl
                   <h6 className="mb-1">Stake</h6>
                   <p className="mb-0 text-primary">
                     {validator.activated_stake ?
-                      `${Math.round(Number(validator.activated_stake) / 1e9).toLocaleString()} SOL` :
+                      `${Math.round(Number(validator.activated_stake)).toLocaleString()} SOL` :
                       'N/A'}
                   </p>
                 </div>

--- a/components/validator/common.tsx
+++ b/components/validator/common.tsx
@@ -6,7 +6,7 @@ import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
 export const StakeLabel: FC<{stake: number}> = ({stake}) => {
     
-    if(stake!=null) {
+    if(stake != null && !isNaN(stake) && stake !== 0) {
         let s = (stake<0) ? stake*-1 : stake;
         let n = new Intl.NumberFormat().format(Number(s.toFixed(0)));
         let color = (stake<0) ? 'bg-danger' : 'bg-white text-black'

--- a/components/validator/delinquency.tsx
+++ b/components/validator/delinquency.tsx
@@ -1,11 +1,9 @@
 import { FC, useEffect, useState } from "react";
 import axios from "axios";
-import config from '../../config.json'
 import { Spinner } from '../common'
 import Chart from "react-google-charts";
 import Calendar from '../calendar';
 
-const API_URL = process.env.API_BASE_URL;
 
 export const DelinquencyChart: FC<{vote_identity: string, first_epoch: number}> = ({vote_identity, first_epoch}) => {
     const [delinquencies, setDelinquencies] = useState(null);
@@ -13,9 +11,7 @@ export const DelinquencyChart: FC<{vote_identity: string, first_epoch: number}> 
     const [startDate, setStartDate] = useState(null)
     
     useEffect(() => {
-        axios(API_URL+config.API_ENDPOINTS.validator_delinquencies+"/"+vote_identity, {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+vote_identity+'/delinquencies')
             .then(async (response) => {
                 let json: [] = response.data;
 
@@ -30,14 +26,12 @@ export const DelinquencyChart: FC<{vote_identity: string, first_epoch: number}> 
             .catch(e => {
             console.log(e);
             })
-        axios(API_URL+config.API_ENDPOINTS.all_epoch_history, {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/epoch/history')
             .then(async (response) => {
                 let json: [] = response.data;
                 setAllEpochs(json)
                 let epoch:any = json.find((epoch: any) => epoch.epoch == first_epoch)
-                let start_date = new Date(epoch.start)
+                let start_date = new Date(epoch.start_time)
                 setStartDate(start_date.getFullYear()+'-'+(start_date.getMonth()+1)+'-'+start_date.getDate())
 
             })

--- a/components/validator/detail.tsx
+++ b/components/validator/detail.tsx
@@ -275,7 +275,7 @@ class ValidatorDetail extends React.Component<validatorDetailI,
 
             let updated_at = new Date(this.state.validator.updated_at);
 
-            let activated_stake = new Intl.NumberFormat().format(Number(this.state.validator.activated_stake.toFixed(0)));
+            let activated_stake = new Intl.NumberFormat().format(Math.round(Number(this.state.validator.activated_stake) / 1e9));
 
             return ( [
                 <div className='container-sm m-1 position-relative d-flex align-items-center validator-detail-header' key='validator-details-header'>

--- a/components/validator/detail.tsx
+++ b/components/validator/detail.tsx
@@ -275,7 +275,7 @@ class ValidatorDetail extends React.Component<validatorDetailI,
 
             let updated_at = new Date(this.state.validator.updated_at);
 
-            let activated_stake = new Intl.NumberFormat().format(Math.round(Number(this.state.validator.activated_stake)));
+            let activated_stake = new Intl.NumberFormat().format(Math.round(Number(this.state.validator.activated_stake) / 1e9));
 
             return ( [
                 <div className='container-sm m-1 position-relative d-flex align-items-center validator-detail-header' key='validator-details-header'>

--- a/components/validator/detail.tsx
+++ b/components/validator/detail.tsx
@@ -18,7 +18,6 @@ import * as browser from '../../lib/browser';
 import { VoteSuccessChart } from './vote_success';
 import { SkipRateChart } from './skip_rate';
 
-const API_URL = process.env.API_BASE_URL;
 
 class ValidatorDetail extends React.Component<validatorDetailI, 
     {
@@ -57,9 +56,7 @@ class ValidatorDetail extends React.Component<validatorDetailI,
         })
     }
     getValidator() {
-        axios(API_URL+config.API_ENDPOINTS.validator+'/'+this.props.vote_identity, {
-          headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+this.props.vote_identity)
           .then(response => {
             let json = response.data as validatorI;
             
@@ -217,10 +214,10 @@ class ValidatorDetail extends React.Component<validatorDetailI,
                 let formatted_date: Date|null = null
 
                 if(isSafari){
-                    let timeZone = event.created_at.slice(-3)+':00';
-                    formatted_date = new Date(event.created_at.substring(0, 19).replace(/-/g, "/")+timeZone)
-                }else{                
-                    formatted_date = new Date(event.created_at)
+                    let timeZone = event.observed_at.slice(-3)+':00';
+                    formatted_date = new Date(event.observed_at.substring(0, 19).replace(/-/g, "/")+timeZone)
+                }else{
+                    formatted_date = new Date(event.observed_at)
                 }
                 let prev_comm = (this.state.jitoCommissionHistory!==null && i+1 < this.state.jitoCommissionHistory.length && this.state.jitoCommissionHistory[i+1].commission_bps != null)  ? this.state.jitoCommissionHistory[i+1].commission_bps/100+' %' : null
                 if(i==this.state.jitoCommissionHistory.length-1) prev_comm = 'N/A';

--- a/components/validator/detail.tsx
+++ b/components/validator/detail.tsx
@@ -275,7 +275,7 @@ class ValidatorDetail extends React.Component<validatorDetailI,
 
             let updated_at = new Date(this.state.validator.updated_at);
 
-            let activated_stake = new Intl.NumberFormat().format(Math.round(Number(this.state.validator.activated_stake) / 1e9));
+            let activated_stake = new Intl.NumberFormat().format(Math.round(Number(this.state.validator.activated_stake)));
 
             return ( [
                 <div className='container-sm m-1 position-relative d-flex align-items-center validator-detail-header' key='validator-details-header'>

--- a/components/validator/epoch_stake.tsx
+++ b/components/validator/epoch_stake.tsx
@@ -1,46 +1,45 @@
 import { FC, useEffect, useState } from "react";
 import axios from "axios";
-import config from '../../config.json'
 import { Spinner } from '../common'
 import Chart from "react-google-charts";
 
-const API_URL = process.env.API_BASE_URL;
 
 export const EpochStakeChart: FC<{vote_identity: string, updateStake: Function}> = ({vote_identity, updateStake}) => {
     const [stakes, setStakes] = useState(null);
     
     useEffect(() => {
-        axios(API_URL+config.API_ENDPOINTS.validator_epoch_stake_accounts+"/"+vote_identity, {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+vote_identity+'/epoch_stake_accounts')
             .then(response => {
-                
+
                 let json = response.data;
 
-                let change = json.activating.amount-json.deactivating.amount;
-                
+                const SOL = 1e9;
+                let change = parseFloat(json.activating.amount_lamports)/SOL - parseFloat(json.deactivating.amount_lamports)/SOL;
+
                 updateStake(change);
-                
+
                 let stakes = [];
                 stakes.push(['Location','Parent','Value (SOL)','Color value']);
                 stakes.push(['Total Epoch Stake Changes',null,0,0]);
                 stakes.push(['Activating','Total Epoch Stake Changes',0,0]);
                 stakes.push(['Deactivating','Total Epoch Stake Changes', 0,0]);
-                
+
                 json.activating.stake_accounts.map((stake) => {
+                    const sol = parseFloat(stake.delegated_amount_lamports)/SOL;
                     stakes.push([
                         stake.pubkey,
                         'Activating',
-                        parseFloat(stake.delegated_amount),
-                        Math.sqrt(parseFloat(stake.delegated_amount))
+                        sol,
+                        Math.sqrt(sol)
                     ])
                 })
                 json.deactivating.stake_accounts.map((stake) => {
+                    const sol = parseFloat(stake.delegated_amount_lamports)/SOL;
                     stakes.push([
                         stake.pubkey,
                         'Deactivating',
-                        parseFloat(stake.delegated_amount),
-                        Math.sqrt(parseFloat(stake.delegated_amount))*-1
+                        sol,
+                        Math.sqrt(sol)*-1
                     ])
                 })
 

--- a/components/validator/epoch_stake.tsx
+++ b/components/validator/epoch_stake.tsx
@@ -14,7 +14,7 @@ export const EpochStakeChart: FC<{vote_identity: string, updateStake: Function}>
                 let json = response.data;
 
                 const SOL = 1e9;
-                let change = json.activating.amount_lamports/SOL - json.deactivating.amount_lamports/SOL;
+                let change = (json.activating?.amount_lamports ?? 0)/SOL - (json.deactivating?.amount_lamports ?? 0)/SOL;
 
                 updateStake(change);
 

--- a/components/validator/epoch_stake.tsx
+++ b/components/validator/epoch_stake.tsx
@@ -14,7 +14,7 @@ export const EpochStakeChart: FC<{vote_identity: string, updateStake: Function}>
                 let json = response.data;
 
                 const SOL = 1e9;
-                let change = parseFloat(json.activating.amount_lamports)/SOL - parseFloat(json.deactivating.amount_lamports)/SOL;
+                let change = json.activating.amount_lamports/SOL - json.deactivating.amount_lamports/SOL;
 
                 updateStake(change);
 
@@ -25,7 +25,7 @@ export const EpochStakeChart: FC<{vote_identity: string, updateStake: Function}>
                 stakes.push(['Deactivating','Total Epoch Stake Changes', 0,0]);
 
                 json.activating.stake_accounts.map((stake) => {
-                    const sol = parseFloat(stake.delegated_amount_lamports)/SOL;
+                    const sol = (stake.delegated_amount_lamports ?? 0)/SOL;
                     stakes.push([
                         stake.pubkey,
                         'Activating',
@@ -34,7 +34,7 @@ export const EpochStakeChart: FC<{vote_identity: string, updateStake: Function}>
                     ])
                 })
                 json.deactivating.stake_accounts.map((stake) => {
-                    const sol = parseFloat(stake.delegated_amount_lamports)/SOL;
+                    const sol = (stake.delegated_amount_lamports ?? 0)/SOL;
                     stakes.push([
                         stake.pubkey,
                         'Deactivating',

--- a/components/validator/gauges.tsx
+++ b/components/validator/gauges.tsx
@@ -15,20 +15,20 @@ export const Gauges: FC<{
 
     let skipGauge = [
         ["Label", "Value"],
-        ["Skip Rate", {v: skip_rate, f: skip_rate.toFixed(1)+'%'}]
+        ["Skip Rate", {v: Number(skip_rate), f: Number(skip_rate).toFixed(1)+'%'}]
         
     ];
     let creditGauge = [
         ["Label", "Value"],
-        ["Vote Credits", {v: credit_ratio, f: credit_ratio.toFixed(1)+'%'}]
+        ["Vote Credits", {v: Number(credit_ratio), f: Number(credit_ratio).toFixed(1)+'%'}]
     ]
     let wizScoreGauge = [
         ["Label", "Value"],
-        ["Wiz Score", {v: wiz_score, f: wiz_score.toFixed(1)+'%'}]
+        ["Wiz Score", {v: Number(wiz_score), f: Number(wiz_score).toFixed(1)+'%'}]
     ]
     let uptimeGauge = [
         ["Label", "Value"],
-        ["Uptime", {v: uptime, f: uptime.toFixed(2)+'%'}]
+        ["Uptime", {v: Number(uptime), f: Number(uptime).toFixed(2)+'%'}]
     ]
 
     let chartStyle = {
@@ -60,7 +60,7 @@ export const Gauges: FC<{
                                     ]
                                 }}
                                 maxValue={5}
-                                value={skip_rate} 
+                                value={Number(skip_rate)}
                                 pointer={{hide:true}}
                                 style={chartStyle}
                                 labels={{tickLabels:{hideMinMax:true}, valueLabel: {formatTextValue: (value) => value+' %', style: { fontSize: '30px'}}}}
@@ -89,7 +89,7 @@ export const Gauges: FC<{
                                         }
                                     ]
                                 }}
-                                value={credit_ratio} 
+                                value={Number(credit_ratio)}
                                 pointer={{hide:true}}
                                 style={chartStyle}
                                 labels={{tickLabels:{hideMinMax:true}, valueLabel: {formatTextValue: (value) => value+' %', style: { fontSize: '30px'}}}}
@@ -120,7 +120,7 @@ export const Gauges: FC<{
                                         }
                                     ]
                                 }}
-                                value={wiz_score} 
+                                value={Number(wiz_score)}
                                 pointer={{hide:true}}
                                 style={chartStyle}
                                 labels={{tickLabels:{hideMinMax:true}, valueLabel: {formatTextValue: (value) => value+' %', style: { fontSize: '30px'}, maxDecimalDigits: 1}}}
@@ -149,7 +149,7 @@ export const Gauges: FC<{
                                         }
                                     ]
                                 }}
-                                value={uptime} 
+                                value={Number(uptime)}
                                 pointer={{hide:true}}
                                 style={chartStyle}
                                 labels={{tickLabels:{hideMinMax:true}, valueLabel: {formatTextValue: (value) => value+' %', style: { fontSize: '30px'}}}}

--- a/components/validator/interfaces.tsx
+++ b/components/validator/interfaces.tsx
@@ -82,8 +82,8 @@ export interface validatorI {
 
 export interface clusterStatsI {
     avg_credit_ratio: number;
-    avg_activated_stake_lamports: string;
-    median_stake_lamports: string;
+    avg_activated_stake_lamports: number | null;
+    median_stake_lamports: number | null;
     avg_commission: number;
     avg_skip_rate: number;
     avg_apy: number;

--- a/components/validator/interfaces.tsx
+++ b/components/validator/interfaces.tsx
@@ -82,8 +82,8 @@ export interface validatorI {
 
 export interface clusterStatsI {
     avg_credit_ratio: number;
-    avg_activated_stake: number;
-    median_stake: number;
+    avg_activated_stake_lamports: string;
+    median_stake_lamports: string;
     avg_commission: number;
     avg_skip_rate: number;
     avg_apy: number;

--- a/components/validator/skip_rate.tsx
+++ b/components/validator/skip_rate.tsx
@@ -1,19 +1,15 @@
 import { FC, useEffect, useState } from "react";
 import axios from "axios";
-import config from '../../config.json'
 import { Spinner } from '../common'
 import Chart from "react-google-charts";
 import * as browser from 'lib/browser';
 
-const API_URL = process.env.API_BASE_URL;
 
 export const SkipRateChart: FC<{vote_identity: string}> = ({vote_identity}) => {
     const [allScores, setAllScores] = useState(null);
     
     useEffect(() => {
-        axios(API_URL+config.API_ENDPOINTS.validator_skip_rate+"/"+vote_identity+"?limit=2000", {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+vote_identity+'/skip_rate?limit=2000')
             .then(response => {
             let json = response.data;
 

--- a/components/validator/vote_success.tsx
+++ b/components/validator/vote_success.tsx
@@ -1,19 +1,15 @@
 import { FC, useEffect, useState } from "react";
 import axios from "axios";
-import config from '../../config.json'
 import { Spinner } from '../common'
 import Chart from "react-google-charts";
 import * as browser from 'lib/browser';
 
-const API_URL = process.env.API_BASE_URL;
 
 export const VoteSuccessChart: FC<{vote_identity: string}> = ({vote_identity}) => {
     const [allScores, setAllScores] = useState(null);
     
     useEffect(() => {
-        axios(API_URL+config.API_ENDPOINTS.validator_vote_success+"/"+vote_identity+"?limit=2000", {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+vote_identity+'/vote_success?limit=2000')
             .then(response => {
             let json = response.data;
 

--- a/components/wizscore.tsx
+++ b/components/wizscore.tsx
@@ -10,7 +10,6 @@ import * as browser from 'lib/browser';
 import WizEmblem from '../public/images/emblem.svg'
 import ordinal from 'ordinal';
 
-const API_URL = process.env.API_BASE_URL;
 
 function WizScoreRow(props) {
 
@@ -393,9 +392,7 @@ class WizScoreWeightings extends React.Component<{},
     }
 
     getWeightings() {
-        axios(API_URL+config.API_ENDPOINTS.weightings, {
-            headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/wiz_score')
             .then(response => {
             let json = response.data;
             
@@ -699,9 +696,7 @@ class WizScoreChart extends React.Component<{
     }    
 
     getWizScores(vote_identity) {
-        axios(API_URL+config.API_ENDPOINTS.validator_wiz_scores+"/"+vote_identity, {
-          headers: {'Content-Type':'application/json'}
-        })
+        axios('/api/v2/validator/'+vote_identity+'/wiz_scores')
           .then(response => {
             let json = response.data;
             

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,0 +1,216 @@
+import axios, { AxiosInstance } from 'axios';
+import type {
+  ClusterStats,
+  EpochInfo,
+  EpochRecord,
+  ValidatorListResponse,
+  ValidatorSortField,
+  ValidatorStakesSortField,
+  OrderDirection,
+  Delinquency,
+  VoteSuccessPoint,
+  SkipRatePoint,
+  LogEntry,
+  CommissionHistoryEntry,
+  JitoCommissionHistoryEntry,
+  WizScorePoint,
+  EpochStakes,
+  EpochStakeAccounts,
+  ValidatorReward,
+} from './api-types';
+
+const API_BASE = process.env.STAKEWIZ_API_BASE ?? 'https://staging-api.stakewiz.com';
+const API_TOKEN = process.env.STAKEWIZ_API_TOKEN ?? '';
+
+class StakewizApiClient {
+  private readonly http: AxiosInstance;
+
+  constructor() {
+    this.http = axios.create({
+      baseURL: `${API_BASE}/v2`,
+      headers: {
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+    });
+  }
+
+  async getClusterStats(): Promise<ClusterStats> {
+    const { data } = await this.http.get<ClusterStats>('/cluster_stats');
+    return data;
+  }
+
+  async getWizScore(): Promise<Record<string, unknown>> {
+    const { data } = await this.http.get<Record<string, unknown>>('/wiz_score');
+    return data;
+  }
+
+  async getEpochInfo(): Promise<EpochInfo> {
+    const { data } = await this.http.get<EpochInfo>('/epoch/info');
+    return data;
+  }
+
+  async getEpochHistory(): Promise<EpochRecord[]> {
+    const { data } = await this.http.get<EpochRecord[]>('/epoch/history');
+    return data;
+  }
+
+  async getEpoch(epoch: number): Promise<EpochRecord> {
+    const { data } = await this.http.get<EpochRecord>(`/epoch/${epoch}`);
+    return data;
+  }
+
+  async getValidators(params: {
+    sort?: ValidatorSortField;
+    order?: OrderDirection;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<ValidatorListResponse> {
+    const { data } = await this.http.get<ValidatorListResponse>('/validators/', { params });
+    return data;
+  }
+
+  async getValidator(voteIdentity: string): Promise<Record<string, unknown>> {
+    const { data } = await this.http.get<Record<string, unknown>>(`/validator/${voteIdentity}`);
+    return data;
+  }
+
+  async getValidatorDelinquencies(
+    voteIdentity: string,
+    params: {
+      sort?: 'date' | 'delinquent_minutes';
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<Delinquency[]> {
+    const { data } = await this.http.get<Delinquency[]>(
+      `/validator/${voteIdentity}/delinquencies`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorVoteSuccess(
+    voteIdentity: string,
+    params: {
+      sort?: 'created_at' | 'vote_success';
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<VoteSuccessPoint[]> {
+    const { data } = await this.http.get<VoteSuccessPoint[]>(
+      `/validator/${voteIdentity}/vote_success`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorSkipRate(
+    voteIdentity: string,
+    params: {
+      sort?: 'created_at' | 'skip_rate';
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<SkipRatePoint[]> {
+    const { data } = await this.http.get<SkipRatePoint[]>(
+      `/validator/${voteIdentity}/skip_rate`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorLog(
+    voteIdentity: string,
+    params: {
+      sort?: 'created_at';
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<LogEntry[]> {
+    const { data } = await this.http.get<LogEntry[]>(
+      `/validator/${voteIdentity}/log`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorCommissionHistory(voteIdentity: string): Promise<CommissionHistoryEntry[]> {
+    const { data } = await this.http.get<CommissionHistoryEntry[]>(
+      `/validator/${voteIdentity}/commission_history`,
+    );
+    return data;
+  }
+
+  async getValidatorJitoCommissionHistory(voteIdentity: string): Promise<JitoCommissionHistoryEntry[]> {
+    const { data } = await this.http.get<JitoCommissionHistoryEntry[]>(
+      `/validator/${voteIdentity}/jito_commission_history`,
+    );
+    return data;
+  }
+
+  async getValidatorWizScores(
+    voteIdentity: string,
+    params: {
+      sort?: 'created_at' | 'wiz_score' | 'avg_wiz_score' | 'score_version';
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<WizScorePoint[]> {
+    const { data } = await this.http.get<WizScorePoint[]>(
+      `/validator/${voteIdentity}/wiz_scores`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorStakes(
+    voteIdentity: string,
+    params: {
+      sort?: ValidatorStakesSortField;
+      order?: OrderDirection;
+      limit?: number;
+    } = {},
+  ): Promise<Record<string, unknown>[]> {
+    const { data } = await this.http.get<Record<string, unknown>[]>(
+      `/validator/${voteIdentity}/stakes`,
+      { params },
+    );
+    return data;
+  }
+
+  async getValidatorEpochStakes(voteIdentity: string): Promise<EpochStakes> {
+    const { data } = await this.http.get<EpochStakes>(
+      `/validator/${voteIdentity}/epoch_stakes`,
+    );
+    return data;
+  }
+
+  async getValidatorEpochStakeAccounts(voteIdentity: string): Promise<EpochStakeAccounts> {
+    const { data } = await this.http.get<EpochStakeAccounts>(
+      `/validator/${voteIdentity}/epoch_stake_accounts`,
+    );
+    return data;
+  }
+
+  async getStakeByWithdrawAuthority(publicKey: string): Promise<string[]> {
+    const { data } = await this.http.get<string[]>(
+      `/stake/by_withdraw_authority/${publicKey}`,
+    );
+    return data;
+  }
+
+  async getValidatorRewards(voteIdentity: string, sinceEpoch: number): Promise<ValidatorReward[]> {
+    const { data } = await this.http.get<ValidatorReward[]>(
+      `/reward/validator/${voteIdentity}`,
+      { params: { since_epoch: sinceEpoch } },
+    );
+    return data;
+  }
+
+  async health(): Promise<unknown> {
+    const { data } = await this.http.get('/health');
+    return data;
+  }
+}
+
+export const apiClient = new StakewizApiClient();

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -1,0 +1,14 @@
+import type { NextApiResponse } from 'next';
+import { AxiosError } from 'axios';
+
+export function handleApiError(err: unknown, res: NextApiResponse): void {
+  if (err instanceof AxiosError) {
+    const status = err.response?.status ?? 500;
+    const body = err.response?.data ?? {
+      error: { code: 'UPSTREAM_ERROR', message: err.message },
+    };
+    res.status(status).json(body);
+    return;
+  }
+  res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } });
+}

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -1,0 +1,139 @@
+export interface ApiError {
+  error: {
+    code: string;
+    message: string;
+    details: Record<string, unknown>;
+  };
+}
+
+export interface ClusterStats {
+  avg_credit_ratio: number | null;
+  avg_activated_stake_lamports: string;
+  median_stake_lamports: string;
+  avg_commission: number | null;
+  avg_skip_rate: number | null;
+  avg_apy: number | null;
+}
+
+export interface EpochInfo {
+  epoch: number;
+  start_slot: number | null;
+  start_time: string | null;
+  slot_height: number | null;
+  duration_seconds: number | null;
+  elapsed_seconds: number | null;
+  remaining_seconds: number | null;
+  epochs_per_year: number | null;
+}
+
+export interface EpochRecord {
+  epoch: number;
+  start_time: string | null;
+  end_time: string | null;
+  duration_seconds: number | null;
+}
+
+export type ValidatorSortField =
+  | 'wiz_score'
+  | 'activated_stake'
+  | 'vote_success'
+  | 'skip_rate'
+  | 'commission'
+  | 'name'
+  | 'vote_identity'
+  | 'updated_at';
+
+export type OrderDirection = 'asc' | 'desc';
+
+export interface ValidatorListResponse {
+  data: Record<string, unknown>[];
+  next_cursor: string | null;
+}
+
+export interface Delinquency {
+  date: string;
+  delinquent_minutes: number;
+}
+
+export interface VoteSuccessPoint {
+  vote_success: number;
+  created_at: string;
+}
+
+export interface SkipRatePoint {
+  skip_rate: number;
+  created_at: string;
+}
+
+export interface LogEntry {
+  old_data: string | null;
+  new_data: string | null;
+  created_at: string;
+}
+
+export interface CommissionHistoryEntry {
+  commission: number;
+  observed_at: string;
+}
+
+export interface JitoCommissionHistoryEntry {
+  commission_bps: number | null;
+  observed_at: string;
+}
+
+export interface WizScorePoint {
+  wiz_score: number | null;
+  avg_wiz_score: number | null;
+  created_at: string;
+  score_version: number | null;
+}
+
+export interface EpochStakes {
+  epoch: number;
+  activating_stake_lamports: string;
+  activating_count: number;
+  deactivating_stake_lamports: string;
+  deactivating_count: number;
+}
+
+export interface StakeAccount {
+  pubkey: string;
+  delegated_amount_lamports: string;
+  activation_epoch: number | null;
+  deactivation_epoch: number | null;
+}
+
+export interface EpochStakeAccountsGroup {
+  amount_lamports: string;
+  count: number;
+  stake_accounts: StakeAccount[];
+}
+
+export interface EpochStakeAccounts {
+  epoch: number;
+  activating: EpochStakeAccountsGroup;
+  deactivating: EpochStakeAccountsGroup;
+}
+
+export interface ValidatorReward {
+  epoch: number;
+  percentage: number | null;
+  apr: number | null;
+  commission: number | null;
+  true_percentage: number | null;
+  apy: number | null;
+}
+
+export type ValidatorStakesSortField =
+  | 'pubkey'
+  | 'delegated_to'
+  | 'balance'
+  | 'credits_observed'
+  | 'delegated_stake'
+  | 'activation_epoch'
+  | 'deactivation_epoch'
+  | 'iteration'
+  | 'rent_exempt_reserve'
+  | 'stake_authority'
+  | 'withdraw_authority'
+  | 'created_at';

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -8,8 +8,8 @@ export interface ApiError {
 
 export interface ClusterStats {
   avg_credit_ratio: number | null;
-  avg_activated_stake_lamports: string;
-  median_stake_lamports: string;
+  avg_activated_stake_lamports: number | null;
+  median_stake_lamports: number | null;
   avg_commission: number | null;
   avg_skip_rate: number | null;
   avg_apy: number | null;
@@ -66,8 +66,8 @@ export interface SkipRatePoint {
 }
 
 export interface LogEntry {
-  old_data: string | null;
-  new_data: string | null;
+  old_data: Record<string, unknown> | null;
+  new_data: Record<string, unknown> | null;
   created_at: string;
 }
 
@@ -98,13 +98,13 @@ export interface EpochStakes {
 
 export interface StakeAccount {
   pubkey: string;
-  delegated_amount_lamports: string;
+  delegated_amount_lamports: number | null;
   activation_epoch: number | null;
   deactivation_epoch: number | null;
 }
 
 export interface EpochStakeAccountsGroup {
-  amount_lamports: string;
+  amount_lamports: number;
   count: number;
   stake_accounts: StakeAccount[];
 }

--- a/pages/api/v2/cluster_stats.ts
+++ b/pages/api/v2/cluster_stats.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../lib/api-client';
+import { handleApiError } from '../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    res.json(await apiClient.getClusterStats());
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/epoch/[epoch].ts
+++ b/pages/api/v2/epoch/[epoch].ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../lib/api-client';
+import { handleApiError } from '../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const epoch = parseInt(req.query.epoch as string, 10);
+  if (isNaN(epoch) || epoch < 0) {
+    return res.status(400).json({ error: { code: 'INVALID_PARAM', message: 'epoch must be a non-negative integer' } });
+  }
+  try {
+    res.json(await apiClient.getEpoch(epoch));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/epoch/history.ts
+++ b/pages/api/v2/epoch/history.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../lib/api-client';
+import { handleApiError } from '../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    res.json(await apiClient.getEpochHistory());
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/epoch/info.ts
+++ b/pages/api/v2/epoch/info.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../lib/api-client';
+import { handleApiError } from '../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    res.json(await apiClient.getEpochInfo());
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/health.ts
+++ b/pages/api/v2/health.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../lib/api-client';
+import { handleApiError } from '../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    res.json(await apiClient.health());
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/reward/validator/[vote_identity].ts
+++ b/pages/api/v2/reward/validator/[vote_identity].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, since_epoch } = req.query;
+
+  if (!since_epoch) {
+    return res.status(400).json({ error: { code: 'MISSING_PARAM', message: 'since_epoch is required' } });
+  }
+  const sinceEpoch = parseInt(since_epoch as string, 10);
+  if (isNaN(sinceEpoch) || sinceEpoch < 0) {
+    return res.status(400).json({ error: { code: 'INVALID_PARAM', message: 'since_epoch must be a non-negative integer' } });
+  }
+
+  try {
+    res.json(await apiClient.getValidatorRewards(vote_identity as string, sinceEpoch));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/stake/by_withdraw_authority/[public_key].ts
+++ b/pages/api/v2/stake/by_withdraw_authority/[public_key].ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { public_key } = req.query;
+  try {
+    res.json(await apiClient.getStakeByWithdrawAuthority(public_key as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/commission_history.ts
+++ b/pages/api/v2/validator/[vote_identity]/commission_history.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity } = req.query;
+  try {
+    res.json(await apiClient.getValidatorCommissionHistory(vote_identity as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/delinquencies.ts
+++ b/pages/api/v2/validator/[vote_identity]/delinquencies.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, sort, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorDelinquencies(vote_identity as string, {
+      sort: sort as 'date' | 'delinquent_minutes' | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/epoch_stake_accounts.ts
+++ b/pages/api/v2/validator/[vote_identity]/epoch_stake_accounts.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity } = req.query;
+  try {
+    res.json(await apiClient.getValidatorEpochStakeAccounts(vote_identity as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/epoch_stakes.ts
+++ b/pages/api/v2/validator/[vote_identity]/epoch_stakes.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity } = req.query;
+  try {
+    res.json(await apiClient.getValidatorEpochStakes(vote_identity as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/index.ts
+++ b/pages/api/v2/validator/[vote_identity]/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity } = req.query;
+  try {
+    res.json(await apiClient.getValidator(vote_identity as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/jito_commission_history.ts
+++ b/pages/api/v2/validator/[vote_identity]/jito_commission_history.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity } = req.query;
+  try {
+    res.json(await apiClient.getValidatorJitoCommissionHistory(vote_identity as string));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/log.ts
+++ b/pages/api/v2/validator/[vote_identity]/log.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorLog(vote_identity as string, {
+      sort: 'created_at',
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/skip_rate.ts
+++ b/pages/api/v2/validator/[vote_identity]/skip_rate.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, sort, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorSkipRate(vote_identity as string, {
+      sort: sort as 'created_at' | 'skip_rate' | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/stakes.ts
+++ b/pages/api/v2/validator/[vote_identity]/stakes.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection, ValidatorStakesSortField } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, sort, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorStakes(vote_identity as string, {
+      sort: sort as ValidatorStakesSortField | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/vote_success.ts
+++ b/pages/api/v2/validator/[vote_identity]/vote_success.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, sort, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorVoteSuccess(vote_identity as string, {
+      sort: sort as 'created_at' | 'vote_success' | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validator/[vote_identity]/wiz_scores.ts
+++ b/pages/api/v2/validator/[vote_identity]/wiz_scores.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../../lib/api-client';
+import { handleApiError } from '../../../../../lib/api-handler';
+import type { OrderDirection } from '../../../../../lib/api-types';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { vote_identity, sort, order, limit } = req.query;
+  try {
+    res.json(await apiClient.getValidatorWizScores(vote_identity as string, {
+      sort: sort as 'created_at' | 'wiz_score' | 'avg_wiz_score' | 'score_version' | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/validators/index.ts
+++ b/pages/api/v2/validators/index.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../../lib/api-client';
+import { handleApiError } from '../../../../lib/api-handler';
+import type { ValidatorSortField, OrderDirection } from '../../../../lib/api-types';
+
+const VALID_SORT: ValidatorSortField[] = [
+  'wiz_score', 'activated_stake', 'vote_success', 'skip_rate',
+  'commission', 'name', 'vote_identity', 'updated_at',
+];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+
+  const { sort, order, limit, cursor } = req.query;
+
+  if (sort && !VALID_SORT.includes(sort as ValidatorSortField)) {
+    return res.status(400).json({ error: { code: 'INVALID_PARAM', message: `sort must be one of: ${VALID_SORT.join(', ')}` } });
+  }
+  if (order && order !== 'asc' && order !== 'desc') {
+    return res.status(400).json({ error: { code: 'INVALID_PARAM', message: 'order must be asc or desc' } });
+  }
+
+  try {
+    res.json(await apiClient.getValidators({
+      sort: sort as ValidatorSortField | undefined,
+      order: order as OrderDirection | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+      cursor: cursor as string | undefined,
+    }));
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/api/v2/wiz_score.ts
+++ b/pages/api/v2/wiz_score.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { apiClient } from '../../../lib/api-client';
+import { handleApiError } from '../../../lib/api-handler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    res.json(await apiClient.getWizScore());
+  } catch (err) {
+    handleApiError(err, res);
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,6 @@ import { useWallet, useConnection } from '@solana/wallet-adapter-react'
 import { checkSolflareEnabled } from '../components/common'
 import { Connection } from '@solana/web3.js'
 
-const API_URL = process.env.API_BASE_URL;
 
 class Homepage extends React.Component<
   {

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import {Header, TopBar, Footer} from 'components/common'
 
-const API_URL = process.env.API_BASE_URL;
-
 export default function Home() {
     return (
         <div>


### PR DESCRIPTION
Implements all 20 v2 endpoints from staging-api.stakewiz.com/v2 as Next.js API routes under /api/v2/, with typed client and shared error handling in lib/.